### PR TITLE
fix: parameterize unlock period

### DIFF
--- a/abis/Vesting.json
+++ b/abis/Vesting.json
@@ -74,6 +74,12 @@
       {
         "indexed": false,
         "internalType": "uint256",
+        "name": "unlockPeriodHours",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
         "name": "duration",
         "type": "uint256"
       },
@@ -245,6 +251,19 @@
   },
   {
     "inputs": [],
+    "name": "getUnlockPeriodHours",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
     "name": "getUnlockedAmount",
     "outputs": [
       {
@@ -322,6 +341,11 @@
       {
         "internalType": "uint256",
         "name": "_initialUnlocked",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_unlockPeriodHours",
         "type": "uint256"
       },
       {
@@ -436,6 +460,19 @@
     "name": "transferOwnership",
     "outputs": [],
     "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "unlockPeriod",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
     "type": "function"
   },
   {

--- a/contracts/vesting/Vesting.sol
+++ b/contracts/vesting/Vesting.sol
@@ -75,7 +75,7 @@ contract Vesting is OwnableUpgradeable {
             _amount >= _initialUnlocked,
             "Vesting: `_initialUnlocked` is greater than `_amount`"
         );
-        require(_unlockPeriodHours > 0, "Vesting: _unlockPeriod is zero");
+        require(_unlockPeriodHours > 0, "Vesting: _unlockPeriodHours is zero");
         require(
             _amount >= _duration,
             "Vesting: _amount must be greater than _duration"

--- a/doc/kor/vesting.md
+++ b/doc/kor/vesting.md
@@ -159,11 +159,12 @@ npx hardhat vesting:deploy --network baobab
   - `--initial`(optional): 초기 unlock 물량을 설정합니다. amount-initial 만큼의 물량이 lock된 채 시작합니다.
   - `--vesting`(optional): vesting proxy 컨트랙트를 지정합니다. 생략시 `~/.iskra-console/deployed/vesting-address.json`의 값을 사용합니다.
   - `--token`(optional): 베스팅할 토큰을 지정합니다. 생략시 `~/.iskra-console/deployed/gametoken-address.json`의 값을 사용합니다.
-  - `--duration`(optional): 베스팅 총 기간을 설정합니다. 730시간 단위입니다. 생략시 기본값 36을 사용합니다.
+  - `--period`(optional): 베스팅 unlock 단위 시간을 설정합니다. 이 시간마다 일정 물량이 unlock이 됩니다. 기본값은 730이고, 단위는 시간입니다.
+  - `--duration`(optional): 베스팅 총 기간을 설정합니다. period 기간을 총 몇 번 할지 설정합니다. 기본값은 36입니다. (730시간 * 36 = 3년)
   
 ```
 npx hardhat gametoken:approve [--signer [signer] --password [password]] --spender [vesting proxy contract address] --amount [amount] [--token [game token address]]
-npx hardhat vesting:prepare [--signer [signer] --password [password]] --beneficiary [a beneficiary address] --amount [amount] [--initial [initial unlocked amount]] [--vesting [vesting proxy]] [--token [game token]] [--duration [duration]]
+npx hardhat vesting:prepare [--signer [signer] --password [password]] --beneficiary [a beneficiary address] --amount [amount] [--initial [initial unlocked amount]] [--vesting [vesting proxy]] [--token [game token]] [--period [unlock period hours]] [--duration [duration]]
 
 ex)
 npx hardhat --network baobab gametoken:approve --spender 0x1A61b1cbe03aC8f6Fd8648de04C5b30bb85E38a0 --amount 1000
@@ -284,7 +285,8 @@ npx hardhat --network baobab vesting:setstart --start "2022-05-01 09:00:00"
   - `--amount`: 베스팅 물량을 설정합니다.
   - `--start`: start 시각을 지정합니다. `yyyy-mm-dd hh:mm:ss` 포멧으로 값을 주어야 하고, 로컬 타임존 기준의 시각을 입력합니다.  - `--initial`(optional): 초기 unlock 물량을 설정합니다. amount-initial 만큼의 물량이 lock된 채 시작합니다.
   - `--token`(optional): 베스팅할 토큰을 지정합니다. 생략시 `~/.iskra-console/deployed/gametoken-address.json`의 값을 사용합니다.
-  - `--duration`(optional): 베스팅 총 기간을 설정합니다. 730시간 단위입니다. 생략시 기본값 36을 사용합니다.
+  - `--period`(optional): 베스팅 unlock 단위 시간을 설정합니다. 이 시간마다 일정 물량이 unlock이 됩니다. 기본값은 730이고, 단위는 시간입니다.
+  - `--duration`(optional): 베스팅 총 기간을 설정합니다. period 기간을 총 몇 번 할지 설정합니다. 기본값은 36입니다. (730시간 * 36 = 3년)
   - `--beacon`(optional): 기 배포된 beacon 컨트랙트를 지정합니다. 생략시 `~/.iskra-console/deployed/vesting-impl-address.json`의 beacon 주소를 사용합니다.
 
 ```

--- a/tasks/Vesting.tx.js
+++ b/tasks/Vesting.tx.js
@@ -72,6 +72,7 @@ task("vesting:prepare", "prepare vesting contract")
   .addOptionalParam("initial", "the initial unlocked amount", "0")
   .addOptionalParam("vesting", "the vesting contract address", "")
   .addOptionalParam("token", "the target token address", "")
+  .addOptionalParam("period", "unlock period(default=730 hours)", "730")
   .addOptionalParam("duration", "the vesting duration(default=36)", "36")
   .setAction(async (taskArgs) => {
     printArguments(taskArgs);
@@ -92,6 +93,7 @@ task("vesting:prepare", "prepare vesting contract")
         taskArgs.beneficiary,
         taskArgs.amount,
         taskArgs.initial,
+        taskArgs.period,
         taskArgs.duration,
         taskArgs.token
       );
@@ -140,6 +142,7 @@ task(
   )
   .addOptionalParam("beacon", "the beacon address", "")
   .addOptionalParam("token", "the target token address", "")
+  .addOptionalParam("period", "unlock period(default=730 hours)", "730")
   .addOptionalParam("duration", "the vesting duration(default=36)", "36")
   .setAction(async (taskArgs) => {
     printArguments(taskArgs);
@@ -165,6 +168,7 @@ task(
         taskArgs.beneficiary,
         taskArgs.amount,
         taskArgs.initial,
+        taskArgs.period,
         taskArgs.duration,
         gameToken.address
       );

--- a/test/vesting/Vesting.test.js
+++ b/test/vesting/Vesting.test.js
@@ -76,6 +76,7 @@ describe("Vesting contract", function () {
           beneficiary1.address,
           300_000,
           0,
+          730,
           36,
           gameToken.address
         )
@@ -86,6 +87,7 @@ describe("Vesting contract", function () {
           beneficiary1.address,
           300_000,
           0,
+          730,
           36,
           gameToken.address
         );
@@ -107,6 +109,7 @@ describe("Vesting contract", function () {
           constants.ZERO_ADDRESS,
           300_000,
           0,
+          730,
           36,
           gameToken.address
         )
@@ -120,6 +123,7 @@ describe("Vesting contract", function () {
           beneficiary1.address,
           300_000,
           0,
+          730,
           36,
           gameToken.address
         )
@@ -134,6 +138,7 @@ describe("Vesting contract", function () {
           beneficiary1.address,
           300_000,
           0,
+          730,
           36,
           gameToken.address
         )
@@ -148,8 +153,24 @@ describe("Vesting contract", function () {
           beneficiary1.address,
           300_000,
           0,
+          730,
           36,
           constants.ZERO_ADDRESS
+        )
+      ).to.be.reverted;
+    });
+
+    it("invalid initialization; invalid period", async function () {
+      await gameToken.approve(vesting.address, toTokenAmount(300_000));
+      await expect(
+        vesting.prepare(
+          owner.address,
+          beneficiary1.address,
+          300_000,
+          0,
+          0,
+          36,
+          gameToken.address
         )
       ).to.be.reverted;
     });
@@ -162,6 +183,7 @@ describe("Vesting contract", function () {
           beneficiary1.address,
           300_000,
           0,
+          730,
           0,
           gameToken.address
         )
@@ -176,6 +198,7 @@ describe("Vesting contract", function () {
           beneficiary1.address,
           59,
           0,
+          730,
           60,
           gameToken.address
         )
@@ -190,6 +213,7 @@ describe("Vesting contract", function () {
           beneficiary1.address,
           0,
           0,
+          730,
           36,
           gameToken.address
         )
@@ -204,6 +228,7 @@ describe("Vesting contract", function () {
           beneficiary1.address,
           300_000,
           0,
+          730,
           36,
           vesting.address
         )
@@ -220,6 +245,7 @@ describe("Vesting contract", function () {
             beneficiary1.address,
             300_000,
             0,
+            730,
             36,
             vesting.address
           )
@@ -235,6 +261,7 @@ describe("Vesting contract", function () {
         beneficiary1.address,
         300_000,
         0,
+        730,
         36,
         gameToken.address
       );
@@ -285,6 +312,7 @@ describe("Vesting contract", function () {
         beneficiary1.address,
         300_000,
         0,
+        730,
         36,
         gameToken.address
       );
@@ -344,6 +372,7 @@ describe("Vesting contract", function () {
         beneficiary1.address,
         300_000,
         0,
+        730,
         36,
         gameToken.address
       );
@@ -444,6 +473,7 @@ describe("Vesting contract", function () {
         beneficiary1.address,
         vestingAmount,
         0,
+        730,
         times,
         gameToken.address
       );
@@ -628,6 +658,7 @@ describe("Vesting contract", function () {
         beneficiary1.address,
         400_000,
         0,
+        730,
         36,
         gameToken.address
       );
@@ -669,6 +700,7 @@ describe("Vesting contract", function () {
         beneficiary1.address,
         300_000,
         0,
+        730,
         36,
         gameToken.address
       );
@@ -710,6 +742,7 @@ describe("Vesting contract", function () {
         beneficiary1.address,
         300_000,
         0,
+        730,
         36,
         gameToken.address
       );
@@ -783,6 +816,7 @@ describe("Vesting contract", function () {
         beneficiary1.address,
         300_000,
         0,
+        730,
         36,
         gameToken.address
       );
@@ -830,6 +864,7 @@ describe("Vesting contract", function () {
         beneficiary1.address,
         300_000,
         0,
+        730,
         36,
         gameToken.address
       );
@@ -843,6 +878,7 @@ describe("Vesting contract", function () {
         beneficiary1.address,
         300_000,
         0,
+        730,
         36,
         gameToken.address
       );
@@ -858,6 +894,7 @@ describe("Vesting contract", function () {
         beneficiary1.address,
         300_000,
         0,
+        730,
         36,
         gameToken.address
       );
@@ -880,6 +917,7 @@ describe("Vesting contract", function () {
         beneficiary1.address,
         300_000,
         0,
+        730,
         36,
         gameToken.address
       );
@@ -981,6 +1019,7 @@ describe("Vesting contract", function () {
           beneficiary1.address,
           300_000,
           0,
+          730,
           36,
           gameToken.address
         )
@@ -993,6 +1032,7 @@ describe("Vesting contract", function () {
             beneficiary1.address,
             300_000,
             0,
+            730,
             36,
             gameToken.address
           )
@@ -1003,6 +1043,7 @@ describe("Vesting contract", function () {
           beneficiary1.address,
           300_000,
           0,
+          730,
           36,
           gameToken.address
         );
@@ -1024,6 +1065,7 @@ describe("Vesting contract", function () {
           beneficiary1.address,
           300_000,
           0,
+          730,
           36,
           gameToken.address
         )
@@ -1034,6 +1076,7 @@ describe("Vesting contract", function () {
           beneficiary1.address,
           300_000,
           0,
+          730,
           36,
           gameToken.address
         );
@@ -1063,6 +1106,7 @@ describe("Vesting contract", function () {
         beneficiary1.address,
         vestingAmount,
         initialAmount,
+        730,
         36,
         gameToken.address
       );


### PR DESCRIPTION
- before: 730 hours fixed unlock period
- after: we can input unlock period during `prepare`
- reason: 
  - game partner may want different unlock period.
  - we want to test claiming with short period.
