### PR TITLE
feat: add funtionality for multiple minters

### DIFF
--- a/abis/MultiToken.json
+++ b/abis/MultiToken.json
@@ -56,7 +56,7 @@
       {
         "indexed": true,
         "internalType": "address",
-        "name": "newBurner",
+        "name": "burner",
         "type": "address"
       },
       {
@@ -66,7 +66,26 @@
         "type": "bool"
       }
     ],
-    "name": "BurnPermissionApproval",
+    "name": "BurnApproval",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "minter",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "bool",
+        "name": "approved",
+        "type": "bool"
+      }
+    ],
+    "name": "MintApproval",
     "type": "event"
   },
   {
@@ -434,6 +453,25 @@
     "inputs": [
       {
         "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "mintApprovals",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
         "name": "to",
         "type": "address"
       },
@@ -607,24 +645,6 @@
     "inputs": [
       {
         "internalType": "address",
-        "name": "burner",
-        "type": "address"
-      },
-      {
-        "internalType": "bool",
-        "name": "approved",
-        "type": "bool"
-      }
-    ],
-    "name": "setApprovalBurnPermission",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
         "name": "operator",
         "type": "address"
       },
@@ -648,6 +668,42 @@
       }
     ],
     "name": "setBaseURI",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "burner",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "approved",
+        "type": "bool"
+      }
+    ],
+    "name": "setBurnApproval",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "minter",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "approved",
+        "type": "bool"
+      }
+    ],
+    "name": "setMintApproval",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"

--- a/contracts/token/ERC1155/MultiToken.sol
+++ b/contracts/token/ERC1155/MultiToken.sol
@@ -24,15 +24,17 @@ contract MultiToken is
     bool public immutable pausable;
     bool public immutable burnable;
 
-    event BurnPermissionApproval(
-        address indexed newBurner,
-        bool indexed approved
-    );
     mapping(address => bool) public burnApprovals;
+    mapping(address => bool) public mintApprovals;
+
     // NOTE:
     // Having a single name is not appropriate for the original ERC1155.
     // However, we added it because most network explorers refer to this field to expose token information.
     string public name;
+
+    event BurnApproval(address indexed burner, bool indexed approved);
+
+    event MintApproval(address indexed minter, bool indexed approved);
 
     constructor(
         string memory uri_,
@@ -75,8 +77,16 @@ contract MultiToken is
 
     modifier hasBurnPermission() {
         require(
-            msg.sender == owner() || burnApprovals[msg.sender],
-            "MultiToken: msg.sender does not have permission to burn"
+            _msgSender() == owner() || burnApprovals[_msgSender()],
+            "MultiToken: the sender does not have permission to burn"
+        );
+        _;
+    }
+
+    modifier hasMintPermission() {
+        require(
+            _msgSender() == owner() || mintApprovals[_msgSender()],
+            "MultiToken: the sender does not have permission to mint"
         );
         _;
     }
@@ -89,14 +99,19 @@ contract MultiToken is
         _unpause();
     }
 
-    function setApprovalBurnPermission(address burner, bool approved)
+    function setBurnApproval(address burner, bool approved)
         external
         onlyOwner
         whenBurnableEnabled
         whenNotPaused
     {
         burnApprovals[burner] = approved;
-        emit BurnPermissionApproval(burner, approved);
+        emit BurnApproval(burner, approved);
+    }
+
+    function setMintApproval(address minter, bool approved) external onlyOwner {
+        mintApprovals[minter] = approved;
+        emit MintApproval(minter, approved);
     }
 
     function mint(
@@ -104,7 +119,7 @@ contract MultiToken is
         uint256 id,
         uint256 amount,
         bytes memory data
-    ) public onlyOwner {
+    ) public hasMintPermission {
         _mint(account, id, amount, data);
     }
 
@@ -113,7 +128,7 @@ contract MultiToken is
         uint256[] memory ids,
         uint256[] memory amounts,
         bytes memory data
-    ) public onlyOwner {
+    ) public hasMintPermission {
         _mintBatch(to, ids, amounts, data);
     }
 

--- a/contracts/token/ERC1155/MultiToken.sol
+++ b/contracts/token/ERC1155/MultiToken.sol
@@ -109,7 +109,11 @@ contract MultiToken is
         emit BurnApproval(burner, approved);
     }
 
-    function setMintApproval(address minter, bool approved) external onlyOwner {
+    function setMintApproval(address minter, bool approved)
+        external
+        onlyOwner
+        whenNotPaused
+    {
         mintApprovals[minter] = approved;
         emit MintApproval(minter, approved);
     }

--- a/test/token/ERC1155/ERC1155.behavior.js
+++ b/test/token/ERC1155/ERC1155.behavior.js
@@ -5,6 +5,7 @@ const { constants, expectRevert } = require("@openzeppelin/test-helpers");
 const { ZERO_ADDRESS } = constants;
 
 const { expect } = require("chai");
+const { ethers } = require("hardhat");
 
 function shouldBehaveLikeERC1155([
   minter,

--- a/test/token/ERC721/ERC721.behavior.js
+++ b/test/token/ERC721/ERC721.behavior.js
@@ -17,8 +17,8 @@ function shouldBehaveLikeERC721() {
     beforeEach(async function () {
       [owner, newOwner, approved, anotherApproved, operator, other] =
         this.signers;
-      await this.token.connect(owner).mint(owner.address, firstTokenId);
-      await this.token.connect(owner).mint(owner.address, secondTokenId);
+      await this.token.connect(owner).safeMint(owner.address, firstTokenId);
+      await this.token.connect(owner).safeMint(owner.address, secondTokenId);
       this.toWhom = other; // default to other for toWhom in context-dependent tests
     });
 
@@ -912,7 +912,7 @@ function shouldBehaveLikeERC721Metadata(name, symbol, uri) {
       let owner;
       beforeEach(async function () {
         owner = this.signers[0];
-        await this.token.mint(owner.address, firstTokenId);
+        await this.token.safeMint(owner.address, firstTokenId);
       });
 
       it("return proper token uri", async function () {

--- a/test/token/MultiToken.test.js
+++ b/test/token/MultiToken.test.js
@@ -111,7 +111,7 @@ describe("MultiToken", function () {
         .connect(firstHolder)
         .burn(firstHolder.address, tokenId, tokenAmount);
       await expect(tx).to.be.revertedWith(
-        "MultiToken: msg.sender does not have permission to burn"
+        "MultiToken: the sender does not have permission to burn"
       );
     });
 
@@ -133,10 +133,8 @@ describe("MultiToken", function () {
         await burnableToken.balanceOf(firstHolder.address, tokenId)
       ).to.be.equal(1);
 
-      await expect(
-        burnableToken.setApprovalBurnPermission(firstHolder.address, true)
-      )
-        .to.emit(burnableToken, "BurnPermissionApproval")
+      await expect(burnableToken.setBurnApproval(firstHolder.address, true))
+        .to.emit(burnableToken, "BurnApproval")
         .withArgs(firstHolder.address, true);
 
       await burnableToken


### PR DESCRIPTION
- ItemNFT
    - multiple minter: add burnApproval and management feature for it
    - mint, mintBatch => safeMint, safeMintBatch(like openzeppelin wizard does)
       -  https://docs.openzeppelin.com/contracts/4.x/wizard
- MultiToken
    - multiple minter