### PR TITLE
fix: same memory type with super type

### DIFF
--- a/contracts/token/ERC1155/MultiToken.sol
+++ b/contracts/token/ERC1155/MultiToken.sol
@@ -149,8 +149,8 @@ contract MultiToken is
 
     function burnBatch(
         address account,
-        uint256[] calldata ids,
-        uint256[] calldata values
+        uint256[] memory ids,
+        uint256[] memory values
     ) public override whenBurnableEnabled hasBurnPermission {
         super.burnBatch(account, ids, values);
     }


### PR DESCRIPTION
For #15 
- Cirtik has commented like this; `However, the changes made for burnBatch() is causing compiler error since it is overriding an already existing function.`
- There is no problem in my case, namely no compile error
- However, it would be better to match the upper function type.