### PR TITLE
fix: Implement the uri_ field external setter from ERC1155

### DIFF
--- a/abis/MultiToken.json
+++ b/abis/MultiToken.json
@@ -711,6 +711,19 @@
   {
     "inputs": [
       {
+        "internalType": "string",
+        "name": "uri_",
+        "type": "string"
+      }
+    ],
+    "name": "setOriginURI",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "uint256",
         "name": "tokenId",
         "type": "uint256"

--- a/abis/MultiToken.json
+++ b/abis/MultiToken.json
@@ -711,19 +711,6 @@
   {
     "inputs": [
       {
-        "internalType": "string",
-        "name": "uri_",
-        "type": "string"
-      }
-    ],
-    "name": "setOriginURI",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
         "internalType": "uint256",
         "name": "tokenId",
         "type": "uint256"
@@ -731,6 +718,19 @@
       {
         "internalType": "string",
         "name": "tokenURI_",
+        "type": "string"
+      }
+    ],
+    "name": "setTokenURI",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "uri_",
         "type": "string"
       }
     ],

--- a/contracts/token/ERC1155/MultiToken.sol
+++ b/contracts/token/ERC1155/MultiToken.sol
@@ -57,6 +57,10 @@ contract MultiToken is
         return ERC1155URIStorage.uri(tokenId);
     }
 
+    function setOriginURI(string calldata uri_) external onlyOwner {
+        _setURI(uri_);
+    }
+
     function setURI(uint256 tokenId, string calldata tokenURI_)
         public
         onlyOwner

--- a/contracts/token/ERC1155/MultiToken.sol
+++ b/contracts/token/ERC1155/MultiToken.sol
@@ -57,11 +57,11 @@ contract MultiToken is
         return ERC1155URIStorage.uri(tokenId);
     }
 
-    function setOriginURI(string calldata uri_) external onlyOwner {
+    function setURI(string calldata uri_) external onlyOwner {
         _setURI(uri_);
     }
 
-    function setURI(uint256 tokenId, string calldata tokenURI_)
+    function setTokenURI(uint256 tokenId, string calldata tokenURI_)
         public
         onlyOwner
     {

--- a/doc/kor/multi_token.md
+++ b/doc/kor/multi_token.md
@@ -91,8 +91,14 @@ npx hardhat multitoken:deploy --name example --network baobab
   - `npx hardhat multitoken:safetransferfrom-batch --from f39fd6e51aad88f6f4ce6ab8827279cfffb92266 --to 70997970c51812dc3a010c7d01b50e0d17dc79c8 --ids 1,2,3,0x8000000000000000000000000000000000000000000000000000000000000000 --amounts 1,2,3,1 --network baobab`
 
 ## uri
-- npx hardhat multitoken:seturi --signer [signer] --password [password] --id [id] --uri [uri] --network [network]
-  - `npx hardhat multitoken:seturi --id 1 --uri 'IT IS SAMPLE URI' --network baobab`
+- npx hardhat multitoken:seturi --signer [signer] --password [password] --uri [uri] --network [network]
+  - `npx hardhat multitoken:seturi --uri 'IT IS SAMPLE URI' --network baobab`
+
+- npx hardhat multitoken:setbaseuri --signer [signer] --password [password] --uri [uri] --network [network]
+  - `npx hardhat multitoken:setbaseuri --uri 'IT IS SAMPLE BASE URI' --network baobab`
+
+- npx hardhat multitoken:settokenuri --signer [signer] --password [password] --id [id] --uri [uri] --network [network]
+  - `npx hardhat multitoken:settokenuri --id 1 --uri 'IT IS SAMPLE TOKEN URI' --network baobab`
 
 ## approval
 - npx hardhat multitoken:setapprovalforall --signer [signer] --password [password] --operator [operator] --approved [true/false] --network [network]

--- a/tasks/MultiToken.tx.js
+++ b/tasks/MultiToken.tx.js
@@ -272,13 +272,53 @@ task("multitoken:seturi", "set URI")
     "The signer signs this transaction. wallet:add first"
   )
   .addOptionalParam("password", "password for decrypting wallet")
+  .addParam("uri", "uri string")
+  .setAction(async (taskArgs) => {
+    printArguments(taskArgs);
+    const wallet = await walletLoad(taskArgs.signer, taskArgs.password);
+    const token = (await getMultiToken(taskArgs.contract)).connect(wallet);
+    const tx = await token.setURI(taskArgs.uri);
+    printTxResult(await tx.wait());
+  });
+
+task("multitoken:setbaseuri", "set Base URI")
+  .addOptionalParam(
+    "contract",
+    "The address of deployed Iskra MultiToken contract",
+    ""
+  )
+  .addOptionalParam(
+    "signer",
+    "The signer signs this transaction. wallet:add first"
+  )
+  .addOptionalParam("password", "password for decrypting wallet")
+  .addParam("uri", "uri string")
+  .setAction(async (taskArgs) => {
+    printArguments(taskArgs);
+    const wallet = await walletLoad(taskArgs.signer, taskArgs.password);
+    const token = (await getMultiToken(taskArgs.contract)).connect(wallet);
+    const tx = await token.setBaseURI(taskArgs.uri);
+    printTxResult(await tx.wait());
+  });
+
+task("multitoken:settokenuri", "set Token URI")
+  .addOptionalParam(
+    "contract",
+    "The address of deployed Iskra MultiToken contract",
+    ""
+  )
+  .addOptionalParam(
+    "signer",
+    "The signer signs this transaction. wallet:add first"
+  )
+  .addOptionalParam("password", "password for decrypting wallet")
   .addParam("id", "The token id")
   .addParam("uri", "uri string")
   .setAction(async (taskArgs) => {
     printArguments(taskArgs);
     const wallet = await walletLoad(taskArgs.signer, taskArgs.password);
     const token = (await getMultiToken(taskArgs.contract)).connect(wallet);
-    const tx = await token.setURI(taskArgs.id, taskArgs.uri);
+    const tx = await token.setTokenURI(taskArgs.id, taskArgs.uri);
     printTxResult(await tx.wait());
   });
 

--- a/test/token/ERC1155/extensions/ERC1155URIStorage.behavior.js
+++ b/test/token/ERC1155/extensions/ERC1155URIStorage.behavior.js
@@ -25,7 +25,7 @@ function shouldBehaveLikeERC1155URIStorage(ERC1155URIStorageMock, holder) {
 
     it("can request the token uri, returning the concatenated uri if a token uri was set", async function () {
       const tokenUri = "1234/";
-      const receipt = await this.token.setURI(tokenId, tokenUri);
+      const receipt = await this.token.setTokenURI(tokenId, tokenUri);
 
       const receivedTokenUri = await this.token.uri(tokenId);
 
@@ -50,7 +50,7 @@ function shouldBehaveLikeERC1155URIStorage(ERC1155URIStorageMock, holder) {
 
     it("can request the token uri, returning the token uri if a token uri was set", async function () {
       const tokenUri = "ipfs://1234/";
-      const receipt = await this.token.setURI(tokenId, tokenUri);
+      const receipt = await this.token.setTokenURI(tokenId, tokenUri);
 
       const receivedTokenUri = await this.token.uri(tokenId);
 

--- a/test/token/MultiToken.test.js
+++ b/test/token/MultiToken.test.js
@@ -169,7 +169,7 @@ describe("MultiToken", function () {
 
     it("should be returned the changed _uri when don't set an uri per tokenId", async function () {
       const newUri = "https://newURI/{id}";
-      await token.setOriginURI(newUri);
+      await token.setURI(newUri);
       expect(await token.uri(tokenId)).to.be.equal(newUri);
     });
 
@@ -177,7 +177,7 @@ describe("MultiToken", function () {
       const baseUri = "https://uri-storage-base-uri/";
       const tokenUri = "test";
       await token.setBaseURI(baseUri);
-      await token.setURI(tokenId, tokenUri);
+      await token.setTokenURI(tokenId, tokenUri);
       expect(await token.uri(tokenId)).to.be.equal(baseUri + tokenUri);
     });
   });

--- a/test/token/MultiToken.test.js
+++ b/test/token/MultiToken.test.js
@@ -7,7 +7,7 @@ describe("MultiToken", function () {
   let MultiToken;
 
   const PAUSER_ROLE = utils.keccak256(utils.toUtf8Bytes("PAUSER_ROLE"));
-  const baseUri = "https://test-base-uri/";
+  const uri = "https://test-uri/";
   const name = "testToken";
   let burnable = false,
     pausable = false;
@@ -27,7 +27,7 @@ describe("MultiToken", function () {
     MultiToken = await ethers.getContractFactory("MultiToken", deployer);
 
     this.token = this.contract = await MultiToken.deploy(
-      baseUri,
+      uri,
       name,
       pausable,
       burnable
@@ -72,7 +72,7 @@ describe("MultiToken", function () {
     let pausableToken;
 
     beforeEach(async function () {
-      pausableToken = await MultiToken.deploy(baseUri, name, true, false);
+      pausableToken = await MultiToken.deploy(uri, name, true, false);
       await pausableToken.deployed();
     });
 
@@ -90,7 +90,7 @@ describe("MultiToken", function () {
     let burnableToken;
 
     beforeEach(async function () {
-      burnableToken = await MultiToken.deploy(baseUri, name, false, true);
+      burnableToken = await MultiToken.deploy(uri, name, false, true);
       await burnableToken.deployed();
     });
 
@@ -154,6 +154,31 @@ describe("MultiToken", function () {
       await expect(tx).to.be.revertedWith(
         "ERC1155: caller is not token owner or approved"
       );
+    });
+  });
+
+  describe("Controlling deployed token URIs", function () {
+    let token;
+    const tokenId = 1;
+
+    beforeEach(async function () {
+      token = await MultiToken.deploy(uri, name, false, false);
+      await token.deployed();
+      await token.mint(deployer.address, tokenId, 1, "0x");
+    });
+
+    it("should be returned the changed _uri when don't set an uri per tokenId", async function () {
+      const newUri = "https://newURI/{id}";
+      await token.setOriginURI(newUri);
+      expect(await token.uri(tokenId)).to.be.equal(newUri);
+    });
+
+    it("should be ignored the origin uri when set the tokenUri and baseUri", async function () {
+      const baseUri = "https://uri-storage-base-uri/";
+      const tokenUri = "test";
+      await token.setBaseURI(baseUri);
+      await token.setURI(tokenId, tokenUri);
+      expect(await token.uri(tokenId)).to.be.equal(baseUri + tokenUri);
     });
   });
 });


### PR DESCRIPTION
`ERC1155URIStorage`'s`_baseURI` and `ERC1155`'s `uri_` serve different purposes. 
`MultiToken` was confusing them and using them incorrectly.